### PR TITLE
add r-universe as additional repo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,3 +34,4 @@ Suggests:
 VignetteBuilder: knitr
 Remotes: 
     ropenscilabs/icon
+Additional_repositories: https://cct-datascience.r-universe.dev/


### PR DESCRIPTION
This will enable macOS and windows binary builds on r-universe.  Currently, r-universe doesn't know where to look for `icons`